### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/a845bcbf-808d-4666-a598-135ab044a067/58b7d0b1-de6c-49d1-990d-ca7754b7b62b/_apis/work/boardbadge/33dd0fe1-2814-4a49-bb66-fe103a8507bf)](https://dev.azure.com/aiw-devops/a845bcbf-808d-4666-a598-135ab044a067/_boards/board/t/58b7d0b1-de6c-49d1-990d-ca7754b7b62b/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#611](https://dev.azure.com/aiw-devops/a845bcbf-808d-4666-a598-135ab044a067/_workitems/edit/611). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.